### PR TITLE
Do not represent Long and Double with scientific notation. Fixes #6.

### DIFF
--- a/xmltojsonlib/build.gradle
+++ b/xmltojsonlib/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 9
         targetSdkVersion 25
         versionCode 11
-        versionName "1.3.2"
+        versionName "1.3.4"
     }
     buildTypes {
         release {

--- a/xmltojsonlib/src/main/java/fr/arnaudguyon/xmltojsonlib/JsonToXml.java
+++ b/xmltojsonlib/src/main/java/fr/arnaudguyon/xmltojsonlib/JsonToXml.java
@@ -28,8 +28,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Locale;
 
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
@@ -45,6 +48,8 @@ import javax.xml.transform.stream.StreamSource;
 public class JsonToXml {
 
     private static final int DEFAULT_INDENTATION = 3;
+    // TODO: Set up Locale in the builder
+    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("0", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
 
     public static class Builder {
 
@@ -216,7 +221,27 @@ public class JsonToXml {
                     prepareArray(node, key, array);
                 } else {
                     String path = node.getPath() + "/" + key;
-                    String value = object.toString();
+                    // JSON numbers are represented either Integer or Double (IEEE 754)
+                    // Long may be represented in scientific notation because they are stored as Double
+                    // This workaround attempts to represent Long and Double objects accordingly
+                    String value;
+                    if (object instanceof Double) {
+                        double d = (double) object;
+                        // If it is a Long
+                        if (d % 1 == 0) {
+                            value = Long.toString((long) d);
+                        } else {
+                            // TODO: Set up number of decimal digits per attribute in the builder
+                            // Set only once. Represent all double numbers up to 20 decimal digits
+                            if (DECIMAL_FORMAT.getMaximumFractionDigits() == 0) {
+                                DECIMAL_FORMAT.setMaximumFractionDigits(20);
+                            }
+                            value = DECIMAL_FORMAT.format(d);
+                        }
+                    } else {
+                        // Integer, Boolean and String are handled here
+                        value = object.toString();
+                    }
                     if (isAttribute(path)) {
                         node.addAttribute(key, value);
                     } else if (isContent(path) ) {


### PR DESCRIPTION
I've spent some time investigating this issue #6. I saw your version 1.3.3, but it didn't solve completely issues with double values. I was aware of these issue for Javascript and I didn't know it happens in JSONObject of Java (although it does make sense).

Basically, Javascript's Number or Java's Double can represent up to 53 bits of precision (IEEE 754). The JSONObject does the same, but it stores numbers as Integer or Double. I couldn't find any object where `object instanceof Long` was true. My PR attempts to parse Long and Double correctly.

For this basic example:
```java
String input =
    "<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>" +
    "<map>" +
    "<number name=\"a\" value=\"42\" />" +
    "<number name=\"b\" value=\"1498094219318\" />" +
    "<number name=\"c\" value=\"0.1\" />" +
    "<number name=\"d\" value=\"0.100\" />" +
    "<number name=\"e\" value=\"1099511627776.5\" />" +
    "<number name=\"f\" value=\"1152921504606846976\" />" +
    "<number name=\"g\" value=\"384307168202282325.33333333333\" />" +
    "</map>";
XmlToJson json = new XmlToJson.Builder(input).build();
JsonToXml xml = new JsonToXml.Builder(json.toJson())
    .forceAttribute("/map/number/name")
    .forceAttribute("/map/number/value")
    .build();
String output = xml.toString();
System.out.println(input + "\n" + output);
```
I will get the following result for:
- v1.3.2
```xml
<?xml version="1.0" encoding="UTF-8"?>
<map>
   <number name="a" value="42" />
   <number name="b" value="1.498094219318E12" /> :(
   <number name="c" value="0.1" />
   <number name="d" value="0.1" />
   <number name="e" value="1.0995116277765E12" /> :(
   <number name="f" value="1.15292150460684698E18" /> :(
   <number name="g" value="3.843071682022823E17" /> :(
</map>
```
- v1.3.3
```xml
<?xml version="1.0" encoding="UTF-8"?>
<map>
   <number name="a" value="42" />
   <number name="b" value="1498094219318" /> :)
   <number name="c" value="0.1" />
   <number name="d" value="0.1" />
   <number name="e" value="1.0995116277765E12" /> :(
   <number name="f" value="1152921504606846976" /> :(
   <number name="g" value="384307168202282304" /> :(
</map>
```
- v1.3.4 (This PR's snapshot)
```xml
<?xml version="1.0" encoding="UTF-8"?>
<?xml version="1.0" encoding="UTF-8"?>
<map>
   <number name="a" value="42" />
   <number name="b" value="1498094219318" /> :)
   <number name="c" value="0.1" />
   <number name="d" value="0.1" />
   <number name="e" value="1099511627776.5" /> :)
   <number name="f" value="1152921504606846976" /> :(
   <number name="g" value="384307168202282304" /> :(
</map>
```

Notes:
1. Number of trailing zeros are lost. 
2. The last two should fail for all of them. More than 53 bits of precision.
